### PR TITLE
Fix undefined constants in api.gs

### DIFF
--- a/_constants.gs
+++ b/_constants.gs
@@ -1,0 +1,31 @@
+/**
+ * System Constants
+ * This file loads first to ensure constants are available to all other modules
+ */
+
+/**
+ * Constants for the system
+ */
+const CONSTANTS = {
+  BATCH_SIZE: 100,
+  CALLBACK_BATCH_SIZE: 50,
+  MAX_EXECUTION_TIME: 300000, // 5 minutes in milliseconds
+  API_RATE_LIMIT: 300, // requests per hour
+  API_RATE_PERIOD: 3600000, // 1 hour in milliseconds
+  MAX_RETRIES: 3,
+  RETRY_DELAY: 2000, // 2 seconds
+  
+  // Time formats to classify games
+  TIME_CONTROLS: {
+    BULLET: [60, 180], // 1-3 minutes
+    BLITZ: [180, 600], // 3-10 minutes  
+    RAPID: [600, 1800], // 10-30 minutes
+    DAILY: [86400, Infinity] // 1+ days
+  },
+  
+  // Variants
+  VARIANTS: [
+    'chess', 'chess960', 'bughouse', 'crazyhouse', 'threecheck',
+    'koth', 'antichess', 'atomic', 'horde', 'racingkings'
+  ]
+};

--- a/config.gs
+++ b/config.gs
@@ -301,30 +301,3 @@ const SystemHealth = {
     return health;
   }
 };
-
-/**
- * Constants for the system
- */
-const CONSTANTS = {
-  BATCH_SIZE: 100,
-  CALLBACK_BATCH_SIZE: 50,
-  MAX_EXECUTION_TIME: 300000, // 5 minutes in milliseconds
-  API_RATE_LIMIT: 300, // requests per hour
-  API_RATE_PERIOD: 3600000, // 1 hour in milliseconds
-  MAX_RETRIES: 3,
-  RETRY_DELAY: 2000, // 2 seconds
-  
-  // Time formats to classify games
-  TIME_CONTROLS: {
-    BULLET: [60, 180], // 1-3 minutes
-    BLITZ: [180, 600], // 3-10 minutes  
-    RAPID: [600, 1800], // 10-30 minutes
-    DAILY: [86400, Infinity] // 1+ days
-  },
-  
-  // Variants
-  VARIANTS: [
-    'chess', 'chess960', 'bughouse', 'crazyhouse', 'threecheck',
-    'koth', 'antichess', 'atomic', 'horde', 'racingkings'
-  ]
-};


### PR DESCRIPTION
Move `CONSTANTS` definition to `_constants.gs` to resolve `ReferenceError` by ensuring proper loading order.

Google Apps Script loads files alphabetically. The `CONSTANTS` object was previously defined in `config.gs`, which loaded after `api.gs` (and `callback.gs`), causing `ReferenceError: CONSTANTS is not defined`. Moving `CONSTANTS` to `_constants.gs` ensures it loads first due to the underscore prefix, making it available to all dependent scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf9a0b6c-6bb2-4654-bedf-75a265c94b7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf9a0b6c-6bb2-4654-bedf-75a265c94b7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

