### PR TITLE
Fix undefined CONSTANTS reference error

### DIFF
--- a/api.gs
+++ b/api.gs
@@ -14,8 +14,12 @@ const ChessAPI = {
    */
   rateLimiter: {
     requests: [],
-    limit: CONSTANTS.API_RATE_LIMIT,
-    period: CONSTANTS.API_RATE_PERIOD
+    get limit() {
+      return CONSTANTS.API_RATE_LIMIT;
+    },
+    get period() {
+      return CONSTANTS.API_RATE_PERIOD;
+    }
   },
   
   /**


### PR DESCRIPTION
Convert `rateLimiter` properties to getters to fix `ReferenceError: CONSTANTS is not defined`.

The error occurred because `CONSTANTS` was accessed during object initialization in `api.gs` before it was fully loaded. Using getters defers access to `CONSTANTS` until runtime, resolving the initialization order issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-6527be10-0c1d-4aa4-955f-57f335d987fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6527be10-0c1d-4aa4-955f-57f335d987fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

