### PR TITLE
Fix duplicate constant declaration

### DIFF
--- a/_constants.gs
+++ b/_constants.gs
@@ -6,7 +6,9 @@
 /**
  * Constants for the system
  */
-const CONSTANTS = {
+// Check if CONSTANTS already exists to avoid redeclaration
+if (typeof CONSTANTS === 'undefined') {
+  var CONSTANTS = {
   BATCH_SIZE: 100,
   CALLBACK_BATCH_SIZE: 50,
   MAX_EXECUTION_TIME: 300000, // 5 minutes in milliseconds
@@ -29,3 +31,4 @@ const CONSTANTS = {
     'koth', 'antichess', 'atomic', 'horde', 'racingkings'
   ]
 };
+}


### PR DESCRIPTION
Conditionally declare `CONSTANTS` to avoid redeclaration errors in Google Apps Script.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4f447f2-9181-44b2-9b89-545f73434ac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a4f447f2-9181-44b2-9b89-545f73434ac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

