### PR TITLE
Send chess callback data with URLs

### DIFF
--- a/callback.gs
+++ b/callback.gs
@@ -115,13 +115,49 @@ class CallbackProcessor {
       callback_timestamp: new Date().toISOString()
     };
     
-    // Extract rating changes
+    // Normalize players structure (white/black or top/bottom)
+    let whitePlayer = null;
+    let blackPlayer = null;
+    if (callbackData.players) {
+      // Direct white/black
+      if (callbackData.players.white || callbackData.players.black) {
+        whitePlayer = callbackData.players.white || null;
+        blackPlayer = callbackData.players.black || null;
+      }
+      // Map from top/bottom by color
+      if ((!whitePlayer || !blackPlayer) && (callbackData.players.top || callbackData.players.bottom)) {
+        const top = callbackData.players.top || {};
+        const bottom = callbackData.players.bottom || {};
+        const topColor = (top.color || '').toLowerCase();
+        const bottomColor = (bottom.color || '').toLowerCase();
+        if (topColor === 'white') whitePlayer = top;
+        if (topColor === 'black') blackPlayer = top;
+        if (bottomColor === 'white') whitePlayer = bottom;
+        if (bottomColor === 'black') blackPlayer = bottom;
+      }
+    }
+    
+    // Extract rating changes from either top-level ratingChange or game.ratingChangeWhite/Black
+    let ratingChangeWhite;
+    let ratingChangeBlack;
     if (callbackData.ratingChange) {
       if (callbackData.ratingChange.white !== undefined) {
+        ratingChangeWhite = callbackData.ratingChange.white;
         update.white_rating_change_exact = callbackData.ratingChange.white;
       }
       if (callbackData.ratingChange.black !== undefined) {
+        ratingChangeBlack = callbackData.ratingChange.black;
         update.black_rating_change_exact = callbackData.ratingChange.black;
+      }
+    }
+    if (callbackData.game) {
+      if (callbackData.game.ratingChangeWhite !== undefined) {
+        ratingChangeWhite = callbackData.game.ratingChangeWhite;
+        update.game_rating_change_white = callbackData.game.ratingChangeWhite;
+      }
+      if (callbackData.game.ratingChangeBlack !== undefined) {
+        ratingChangeBlack = callbackData.game.ratingChangeBlack;
+        update.game_rating_change_black = callbackData.game.ratingChangeBlack;
       }
     }
     
@@ -135,14 +171,12 @@ class CallbackProcessor {
       }
     }
     
-    // Extract pre-game ratings if available
-    if (callbackData.players) {
-      if (callbackData.players.white && callbackData.players.white.rating) {
-        update.white_rating_pregame_callback = callbackData.players.white.rating;
-      }
-      if (callbackData.players.black && callbackData.players.black.rating) {
-        update.black_rating_pregame_callback = callbackData.players.black.rating;
-      }
+    // Extract pre-game ratings if available (normalized)
+    if (whitePlayer && whitePlayer.rating !== undefined) {
+      update.white_rating_pregame_callback = whitePlayer.rating;
+    }
+    if (blackPlayer && blackPlayer.rating !== undefined) {
+      update.black_rating_pregame_callback = blackPlayer.rating;
     }
     
     // Extract additional callback data fields
@@ -175,21 +209,81 @@ class CallbackProcessor {
     // Store full raw callback data for future reference
     update.callback_raw_data = JSON.stringify(callbackData);
     
-    // Determine my pre-game rating and opponent's
-    const username = ConfigManager.get('username').toLowerCase();
+    // Determine me vs opponent, compute rating changes and pregame by subtraction, and capture profile fields
+    const configUsername = (ConfigManager.get('username') || '').toLowerCase();
+    let isWhite = false;
+    let myPlayer = null;
+    let opponentPlayer = null;
     
-    if (callbackData.players) {
-      const isWhite = callbackData.players.white && 
-                     callbackData.players.white.username &&
-                     callbackData.players.white.username.toLowerCase() === username;
-      
-      if (isWhite) {
-        update.my_rating_pregame_callback = update.white_rating_pregame_callback;
-        update.opponent_rating_pregame_callback = update.black_rating_pregame_callback;
-      } else {
-        update.my_rating_pregame_callback = update.black_rating_pregame_callback;
-        update.opponent_rating_pregame_callback = update.white_rating_pregame_callback;
+    if (whitePlayer && whitePlayer.username && whitePlayer.username.toLowerCase() === configUsername) {
+      isWhite = true;
+      myPlayer = whitePlayer;
+      opponentPlayer = blackPlayer;
+    } else if (blackPlayer && blackPlayer.username && blackPlayer.username.toLowerCase() === configUsername) {
+      isWhite = false;
+      myPlayer = blackPlayer;
+      opponentPlayer = whitePlayer;
+    } else if (callbackData.players && (callbackData.players.top || callbackData.players.bottom)) {
+      const top = callbackData.players.top || {};
+      const bottom = callbackData.players.bottom || {};
+      if (top.username && top.username.toLowerCase() === configUsername) {
+        myPlayer = top;
+        opponentPlayer = bottom;
+        isWhite = (top.color || '').toLowerCase() === 'white';
+      } else if (bottom.username && bottom.username.toLowerCase() === configUsername) {
+        myPlayer = bottom;
+        opponentPlayer = top;
+        isWhite = (bottom.color || '').toLowerCase() === 'white';
       }
+    }
+    
+    // Set my/opponent pregame convenience fields (from "pregame" values captured above)
+    if (isWhite) {
+      update.my_rating_pregame_callback = update.white_rating_pregame_callback;
+      update.opponent_rating_pregame_callback = update.black_rating_pregame_callback;
+    } else {
+      update.my_rating_pregame_callback = update.black_rating_pregame_callback;
+      update.opponent_rating_pregame_callback = update.white_rating_pregame_callback;
+    }
+    
+    // Map rating changes to me/opponent
+    if (ratingChangeWhite !== undefined && ratingChangeBlack !== undefined) {
+      update.my_rating_change_callback = isWhite ? ratingChangeWhite : ratingChangeBlack;
+      update.opponent_rating_change_callback = isWhite ? ratingChangeBlack : ratingChangeWhite;
+    }
+    
+    // Compute pregame by subtraction using player.rating - ratingChange
+    const myAfter = myPlayer && typeof myPlayer.rating === 'number' ? myPlayer.rating : null;
+    const oppAfter = opponentPlayer && typeof opponentPlayer.rating === 'number' ? opponentPlayer.rating : null;
+    const myDelta = (isWhite ? ratingChangeWhite : ratingChangeBlack);
+    const oppDelta = (isWhite ? ratingChangeBlack : ratingChangeWhite);
+    if (typeof myAfter === 'number' && typeof myDelta === 'number') {
+      update.my_pregame_rating = myAfter - myDelta;
+    }
+    if (typeof oppAfter === 'number' && typeof oppDelta === 'number') {
+      update.opponent_pregame_rating = oppAfter - oppDelta;
+    }
+    
+    // Capture profile fields for me and opponent
+    const toDate = (epochSeconds) => {
+      if (typeof epochSeconds === 'number') return new Date(epochSeconds * 1000);
+      return '';
+    };
+    if (myPlayer) {
+      if (myPlayer.countryName !== undefined) update.my_country_name_callback = myPlayer.countryName;
+      if (myPlayer.defaultTab !== undefined) update.my_default_tab_callback = myPlayer.defaultTab;
+      if (myPlayer.postMoveAction !== undefined) update.my_post_move_action_callback = myPlayer.postMoveAction;
+      if (myPlayer.membershipLevel !== undefined) update.my_membership_level_callback = myPlayer.membershipLevel;
+      if (myPlayer.membershipCode !== undefined) update.my_membership_code_callback = myPlayer.membershipCode;
+      if (myPlayer.memberSince !== undefined) update.my_member_since_callback = toDate(myPlayer.memberSince);
+    }
+    if (opponentPlayer) {
+      if (opponentPlayer.countryName !== undefined) update.opponent_country_name_callback = opponentPlayer.countryName;
+      if (opponentPlayer.defaultTab !== undefined) update.opponent_default_tab_callback = opponentPlayer.defaultTab;
+      if (opponentPlayer.postMoveAction !== undefined) update.opponent_post_move_action_callback = opponentPlayer.postMoveAction;
+      if (opponentPlayer.membershipLevel !== undefined) update.opponent_membership_level_callback = opponentPlayer.membershipLevel;
+      if (opponentPlayer.membershipCode !== undefined) update.opponent_membership_code_callback = opponentPlayer.membershipCode;
+      if (opponentPlayer.memberSince !== undefined) update.opponent_member_since_callback = toDate(opponentPlayer.memberSince);
     }
     
     return update;

--- a/sheets.gs
+++ b/sheets.gs
@@ -98,6 +98,17 @@ const SheetsManager = {
       'callback_pgn_headers', 'callback_analysis_depth', 'callback_best_move', 'callback_evaluation',
       'callback_clocks', 'callback_move_times', 'callback_raw_data',
       
+      // Additional callback-derived fields (rating changes, profiles)
+      'game_rating_change_white', 'game_rating_change_black',
+      'my_rating_change_callback', 'opponent_rating_change_callback',
+      'my_pregame_rating', 'opponent_pregame_rating',
+      'my_country_name_callback', 'opponent_country_name_callback',
+      'my_default_tab_callback', 'opponent_default_tab_callback',
+      'my_post_move_action_callback', 'opponent_post_move_action_callback',
+      'my_membership_level_callback', 'opponent_membership_level_callback',
+      'my_membership_code_callback', 'opponent_membership_code_callback',
+      'my_member_since_callback', 'opponent_member_since_callback',
+      
       // Processing metadata
       'processed_timestamp', 'processing_version'
     ];


### PR DESCRIPTION
Enhance callback processing to include user/opponent rating changes, pre-game ratings, and profile fields in the `Games` sheet.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a69d534-4887-4e90-a3dd-8e6e0d6a8602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a69d534-4887-4e90-a3dd-8e6e0d6a8602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

